### PR TITLE
Add TypeScript declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,10 @@
+/**
+ * @param {T} object - The object to clone.
+ * @param {boolean} [copy=false] - Set to "true" to deep copy Buffer, TypedArrays, Map, Set, Date and RegExp objects.
+ * @returns {T}
+ */
+declare function fastDeepClone<T>(object : T, copy? : boolean) : T;
+
+declare module 'fast-deepclone' {
+    export = fastDeepClone;
+}


### PR DESCRIPTION
Add TypeScript declarations

This implementation allows importing using the syntax "import deepClone = require('fast-deepclone')". 

It does not support the syntax "import * as deepClone from 'fast-deepclone'". This could be achieved by adding a dummy namespace with the same name as the declared function, e.g. "namespace fastDeepClone {}", but I noticed this doesn't play nicely with an IDE like IntelliJ IDEA - it wasn't picking up parameter hints, and maybe the JSDoc.