### PR TITLE
Issue #2: Add support for cloning class instances that inherit from M…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.log
 build/
 node_modules/
+/.idea/

--- a/test/deepclone.test.js
+++ b/test/deepclone.test.js
@@ -104,6 +104,56 @@ describe('deepclone unit tests', () => {
     } while (itsrc.value);
   });
 
+  it('clone/copy: class extending Map', () => {
+    let customMethodWasCalled = false;
+
+    class CustomMap extends Map {
+      constructor(iterable) {
+        super(iterable);
+        this.myCustomProperty = 'someValue';
+      }
+
+      get(key) {
+        customMethodWasCalled = true;
+        return super.get(key);
+      }
+    }
+
+    const src = {
+      foo: 'bar',
+      bar: 123,
+      baz: new CustomMap([[1, 2], [2, 3], [3, 4]])
+    };
+
+    const cloned = deepclone(src);
+
+    assert.deepEqual(src, cloned);
+    assert.strictEqual(src.baz, cloned.baz);
+
+    const copied = deepclone(src, true);
+
+    assert.deepEqual(src, copied);
+    assert.notStrictEqual(src.baz, copied.baz);
+
+    // no spread operator in Node v4 :-(
+    assert.equal(src.baz.size, copied.baz.size);
+    const
+      itsrc = src.baz.entries(),
+      itcopied = src.baz.entries();
+
+    do {
+      itsrc.next();
+      itcopied.next();
+      assert.deepEqual(itsrc.value, itcopied.value);
+    } while (itsrc.value);
+
+    copied.baz.get('anything');
+
+    assert.strictEqual(src.baz.myCustomProperty, copied.baz.myCustomProperty);
+    assert.strictEqual(src.baz.get, copied.baz.get);
+    assert.ok(customMethodWasCalled);
+  });
+
   it('clone/copy: Set', () => {
     const src = {
       foo: 'bar',
@@ -132,6 +182,56 @@ describe('deepclone unit tests', () => {
       itcopied.next();
       assert.deepEqual(itsrc.value, itcopied.value);
     } while (itsrc.value);
+  });
+
+  it('clone/copy: class extending Set', () => {
+    let customMethodWasCalled = false;
+
+    class CustomSet extends Set {
+      constructor(iterable) {
+        super(iterable);
+        this.myCustomProperty = 'someValue';
+      }
+
+      has(key) {
+        customMethodWasCalled = true;
+        return super.has(key);
+      }
+    }
+
+    const src = {
+      foo: 'bar',
+      bar: 123,
+      baz: new CustomSet([1, 2, 3, 4, 5])
+    };
+
+    const cloned = deepclone(src);
+
+    assert.deepEqual(src, cloned);
+    assert.strictEqual(src.baz, cloned.baz);
+
+    const copied = deepclone(src, true);
+
+    assert.deepEqual(src, copied);
+    assert.notStrictEqual(src.baz, copied.baz);
+
+    // no spread operator in Node v4 :-(
+    assert.equal(src.baz.size, copied.baz.size);
+    const
+      itsrc = src.baz.entries(),
+      itcopied = src.baz.entries();
+
+    do {
+      itsrc.next();
+      itcopied.next();
+      assert.deepEqual(itsrc.value, itcopied.value);
+    } while (itsrc.value);
+
+    copied.baz.has('anything');
+
+    assert.strictEqual(src.baz.myCustomProperty, copied.baz.myCustomProperty);
+    assert.strictEqual(src.baz.has, copied.baz.has);
+    assert.ok(customMethodWasCalled);
   });
 
   it('clone/copy: Buffer', () => {


### PR DESCRIPTION
Fixes issue #2: Add support for cloning class instances that inherit from Map or Set.

This is achieved by:

  - Cloning the instance using existing functionality.
  - Copying the prototype from the original object.
  - Copying all (own) properties from the source to the target.
  - Cloning the instance as if it were an object.

This also required splitting most of "cloneObject()" into an extra function, "cloneObjectToTarget", so we can pass in an existing target (i.e. cloned) object. (Ideally, we'd move the value dispatch logic into a separate function, which could help with Issue #1, where you can't pass a Map in as the root object to clone.)

(I'm not a C++ expert so may not have done some things correctly, like passing objects by value instead of by reference.)

While this is possibly a niche case, I hope you consider supporting it in fast-deepclone!

TODO:

  - Consider not copying a property if it already exists on the target.
  - Re-run benchmarks, as this extra cloning will probably slow things down when cloning Sets/Maps. (As an optimisation, maybe we can skip the extra cloning steps if the original object's prototype is just "Map" or "Set"?)
