### PR TITLE
Fixed typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This module also allows to either keep references or to duplicate the following 
 
 ## Installation
 
-`npm fast-deepclone`
+`npm i fast-deepclone`
 
 This module can only be used with NodeJS (tested on all major versions from v4 to v8 included).
 


### PR DESCRIPTION
By the way `npm i fast-deepclone` DOES NOT WORK RIGHT NOW (see Issue https://github.com/scottinet/fast-deepclone/issues/15 ). I just figured it should, and so I should fix this typo.